### PR TITLE
画像保存の条件分岐

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,9 +5,10 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   process resize_to_fit: [800, 800]
   # 暫定で岡田が画像リサイズ指定しています。適宜変更してください。
+
   # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
+  storage :file if Rails.env.development? || Rails.env.test?
+  storage :fog if Rails.env.production?
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:


### PR DESCRIPTION
# What
画像のアップロード先を開発環境と本番環境で分けたい

# Why
chat-spaceと同様にすると全てawsに保存され、デプロイ担当者しか保存できないため

・image_uploader.rbの記述以外はchat-spaceと同様の設定をしています。
・この記述で適切か確認してほしいです。