### PR TITLE
フラッシュメッセージの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,4 +35,5 @@
 @import "modules/category.scss";
 // ログイン
 @import "login/login.scss";
-
+// フラッシュメッセージ
+@import 'modules/_flash';

--- a/app/assets/stylesheets/modules/_flash.scss
+++ b/app/assets/stylesheets/modules/_flash.scss
@@ -1,0 +1,13 @@
+.flash {
+  padding:1vh 1vh;
+  text-align: center;
+  font-size: 14px;
+  color: $white;
+  &__alert{
+    background-color: #FF3333;
+  }
+  &__notice {
+    background-color: $red;
+  }
+}
+

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,0 +1,2 @@
+- flash.each do |key, value|
+  = content_tag(:div, value, class: "flash flash__#{key}")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,4 +11,5 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    = render 'layouts/flash'
     = yield


### PR DESCRIPTION
# What
フラッシュメッセージの実装

# Why
画面遷移の際、便利なので

# How to
基本的にchatspaceのと同じです。
noticeとalertが使えます。

<img width="1438" alt="スクリーンショット 2019-05-18 12 42 04" src="https://user-images.githubusercontent.com/49383851/57964100-6f299080-796a-11e9-800a-0b960279637a.png">
