### PR TITLE
addressesテーブルに住所の登録、及びsign_up/in機能の調整

### DIFF
--- a/app/assets/stylesheets/registration/address.scss
+++ b/app/assets/stylesheets/registration/address.scss
@@ -10,6 +10,18 @@
   vertical-align: middle;
 }
 
+select#address_prefecture_code {
+  width: 100%;
+  height: 60px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #aaa;
+  background-color: $white;
+  line-height: 1.5;
+  font-size: 14px;
+  cursor: pointer;
+}
+
 // 「次へ進む」がカーソル表示されなかったので付け加え
 .information-btn {
   cursor:pointer;

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,12 +1,25 @@
 class AddressesController < ApplicationController
+  require 'jp_prefecture'
+  before_action :authenticate_user!, only: [:new, :create]
   
   def new
+    @address = Address.new
   end
 
   def create
+    @address = Address.create(address_params)
+    if @address.save
+      redirect_to new_payment_path, notice: '住所登録に成功しました'
+    else
+      redirect_to new_address_path, notice: '登録に失敗しました'
+    end
   end
 
   def edit
   end
 
+  private
+  def address_params
+    params.require(:address).permit(:postcode, :prefecture_code, :city, :street, :building, :phone).merge(user_id: current_user.id)
+  end
 end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,23 +1,24 @@
 class PaymentsController < ApplicationController
-  # before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, only: :new
   require 'payjp'
 
   def show
   end
 
   def new
-    # master = User.find(3)
-    # payment = Payment.new
+    @payment = Payment.new
   end
 
   def create
-    # Payjp.api_key = 'sk_test_8b4d3c925604e0aef4191408'
+    Payjp.api_key = 'sk_test_8b4d3c925604e0aef4191408'
+    # 本来は上記の秘密は環境変数として登録すべきですが、みんなで共有するにはどうすればいいかわからないでの保留です。
+    # test鍵なので最悪漏れても影響ないです。
     customer = Payjp::Customer.create(card: params[:payjpToken])
-    @payment = Payment.new(user_id: '2', customer_id: customer.id, card_id: customer.default_card)
+    @payment = Payment.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
     if @payment.save
-      redirect_to root_path, notice: '会員登録は全て完了しました'
+      redirect_to root_path, notice: '会員登録は全て完了しました。メルカリ(偽)をお楽しみください！'
     else
-      redirect_to new_payment_path
+      redirect_to new_payment_path, notice; 'クレジットカード登録に失敗しました'
     end
   end
 
@@ -30,6 +31,6 @@ class PaymentsController < ApplicationController
   private
 
   def set_payment
-    # @payment = Payment.where(user_id: current_user.id).first if Payment.where(user_id: current_user.id).present?
+    @payment = Payment.where(user_id: current_user.id).first if Payment.where(user_id: current_user.id).present?
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,9 +17,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     @user = User.new(sign_up_params)
     if @user.save
-      render :complete
+      redirect_to new_address_path, notice: '会員情報登録に成功しました'
     else
-      render :new
+      render :new, notice: '入力に誤りがあります'
     end
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,10 @@
+class Address < ApplicationRecord
+  belongs_to :user
+  include JpPrefecture
+  jp_prefecture :prefecture_code
+  
+    validates :postcode, presence:true
+    validates :prefecture, presence:true
+    validates :city, presence:true
+    validates :street, presence:true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,5 @@ class User < ApplicationRecord
   # belongs_to_active_hash :prefecture
   has_many :likes
   has_one :payment
+  has_one :address
 end

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -5,41 +5,40 @@
     %h2.register-main__container--header お届け先住所入力
 
     .register-inner
-      = form_for(root_path) do |f|
+      = form_for @address do |f|
         .register-inner_contents
           .form-group
-            %span.registration_font 郵便番号
+            =f.label '郵便番号', class: 'registration_font'
             %span.form-require 必須
             .cardPage__content__form--error
               必須項目です
-            %input.input.input-default{name: 'zip-code', placeholder: '例)123-4567', 'data-region':'jp', maxlength:'8', pattern:'\\d{3}-\\d{4}', value: ""}
+            = f.text_field :postcode, class: 'input-default', placeholder: '例)123-4567', 'data-region':'jp', maxlength:'8', pattern:'\\d{3}-\\d{4}', value: ""
           .form-group
-            %span.registration_font 都道府県
+            =f.label '都道府県', class: 'registration_font'
             %span.form-require 必須
             .cardPage__content__form--error
               必須項目です
-            %div.select-prefecture
-              = render 'users/prefecture'
+            = f.collection_select :prefecture_code, JpPrefecture::Prefecture.all, :code, :name
           .form-group
-            %span.registration_font 市区町村
+            =f.label '市区町村', class: 'registration_font'
             %span.form-require 必須
             .cardPage__content__form--error
               必須項目です
-            %input.input.input-default{name: 'address1', placeholder: "例) 新宿区西新宿"}
+            = f.text_field :city, class: 'input-default', placeholder: "例) 新宿区西新宿"
           .form-group
-            %span.registration_font 番地(全角)
+            =f.label '番地(全角)', class: 'registration_font'
             %span.form-require 必須
             .cardPage__content__form--error
               必須項目です
-            %input.input.input-default{name: 'address2', placeholder: "例) ２丁目８−１"}
+            = f.text_field :street, class: 'input-default', placeholder: "例) ２丁目８−１"
           .form-group
-            %span.registration_font 建物名
+            =f.label '建物名', class: 'registration_font'
             %span.form-any 任意
-            %input.input.input-default{name: 'address2', placeholder: "例) メルカリビル９９"}
+            = f.text_field :building, class: 'input-default', placeholder: "例) メルカリビル９９"
           .form-group
-            %span.registration_font 電話番号
+            =f.label '電話番号', class: 'registration_font'
             %span.form-any 任意
-            %input.input.input-default{name: 'phone', placeholder: "例) 09012345678"}
+            = f.text_field :phone, class: 'input-default', placeholder: "例) 09012345678", maxlength:'11', value: ""
           %p.informationConfirmationMessage
             ※ お届け先住所は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           = f.submit "次へ進む", class: "information-btn", action: 'payments/new'

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -7,7 +7,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
-  inflect.uncountable %w(address)
+  # inflect.uncountable %w(address)
   inflect.uncountable %w(size)
 end
 


### PR DESCRIPTION
# What
会員情報登録→住所登録→クレジットカード登録の流れ実装

# Why
メルカリで商品購入の際に必要な機能のため

# How to
1)会員情報の登録→谷さん担当
<img width="1438" alt="スクリーンショット 2019-05-18 14 56 58" src="https://user-images.githubusercontent.com/49383851/57965493-dd2c8280-797f-11e9-8acf-f00fee723718.png">
2)ログインページ
<img width="1438" alt="スクリーンショット 2019-05-18 14 56 45" src="https://user-images.githubusercontent.com/49383851/57965500-0220f580-7980-11e9-95ce-b304d803ee4d.png">
3)住所登録ページ（この時すでにサインイン状態です）
<img width="1438" alt="スクリーンショット 2019-05-18 14 56 18" src="https://user-images.githubusercontent.com/49383851/57965506-19f87980-7980-11e9-8c5b-c563333b071d.png">
4)クレジットカード登録ページ
<img width="1438" alt="スクリーンショット 2019-05-18 14 56 05" src="https://user-images.githubusercontent.com/49383851/57965515-2d0b4980-7980-11e9-8aca-546d68cf295a.png">
5)会員情報全て登録完了
<img width="1438" alt="スクリーンショット 2019-05-18 14 55 41" src="https://user-images.githubusercontent.com/49383851/57965522-3a283880-7980-11e9-9c14-9b67094d9138.png">